### PR TITLE
エラーや金額などに関する4つのバグを修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 DRINKS = [
-  { name: 'コーヒー', price: '300' },
-  { name: 'カフェラテ', price: '400' },
-  { name: 'チャイ', price: '460' },
-  { name: 'エスプレッソ', price: '340' },
-  { name: '緑茶', price: '450' }
+  { name: 'コーヒー', price: 300 },
+  { name: 'カフェラテ', price: 400 },
+  { name: 'チャイ', price: 460 },
+  { name: 'エスプレッソ', price: 340 },
+  { name: '緑茶', price: 450 }
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '470' },
-  { name: 'アップルパイ', price: '520' },
-  { name: 'ホットサンド', price: '410' }
+  { name: 'チーズケーキ', price: 470 },
+  { name: 'アップルパイ', price: 520 },
+  { name: 'ホットサンド', price: 410 }
 ].freeze
 
 def take_order(menus)
@@ -19,7 +19,7 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
@@ -30,5 +30,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = DRINKS[order1][:price] + FOODS[order2][:price]
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
以下の４つのバグを修正しました。

### 1. 頼んだつもりのメニューが選択できない。
取り出したい配列の要素の指定は変数order_numberの値によって決定される。
配列の要素の指定は0から始まる整数オブジェクトによるが、変数order_numberの値をコンソールから入力する際に表示されるメニューのインデックスは1から始まっているため、ユーザーの認識にプログラムとの齟齬が生じることとなる。
したがって、変数order_numberから配列の要素番号とメニューインデックスの差である1を調整した。

### 2. 最後の番号のメニューを選択するとエラーとなる。
合計金額を計算する変数totalにおける変数と配列の組み合わせがDRINKSとFOODSで逆である。フードメニューには(4)，(5)番（配列要素3番，4番）がないためエラーが発生する。
したがって、DRINKSとFOODSの配列名称を入れ替えた。

### 3. お会計額が異様に高い。
いずれのハッシュも:priceの値が文字列オブジェクトになっているため、数値の足し算ではなく文字列の結合になっている。
したがって、:priceの値を整数オブジェクトに変更した。

### 4. 違う番号のドリンク、フードを注文したとき、お会計が正しくない。
例: (1)コーヒー と (2)アップルパイを頼むと、お会計が意図した金額にならない。
=>2つ目のバグと同様，合計金額を計算する変数totalにおける変数と配列の組み合わせがDRINKSとFOODSで逆である。ユーザーがドリンクだと思って入力した番号がフードの配列に渡されるため、齟齬が生じる。
したがって、DRINKSとFOODSの配列名称を入れ替えた。

以上、よろしくお願いいたします。